### PR TITLE
Generate preprocessed model files for imgSaver via catkin project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+warehouse/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-warehouse/
+models/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,16 +1,16 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(warehouse)
 
-find_package(catkin REQUIRED)
-catkin_package()
+find_package(catkin REQUIRED COMPONENTS gazebo_ros)
+catkin_package(DEPENDS gazebo_ros)
 
 # create the appropriate files for tools
-set(BUILD_MODEL_DIR ${PROJECT_SOURCE_DIR}/warehouse)
+set(BUILD_MODEL_DIR ${PROJECT_SOURCE_DIR}/models)
 
 file(GLOB SUBDIRS ${PROJECT_SOURCE_DIR}/3Dwarehouse/tools/*)
 foreach(SUBDIR ${SUBDIRS})
     get_filename_component(MODEL_NAME ${SUBDIR} NAME)
-    set(MODEL_DIR ${BUILD_MODEL_DIR}/models/${MODEL_NAME})
+    set(MODEL_DIR ${BUILD_MODEL_DIR}/${MODEL_NAME})
 
     # create the description.sdf for the model
     configure_file(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.0.2)
 project(warehouse)
 
 find_package(catkin REQUIRED)
+catkin_package()
 
 ## Mark other files for installation (e.g. launch and bag files, etc.)
 # install(FILES
@@ -9,3 +10,23 @@ find_package(catkin REQUIRED)
 #   # myfile2
 #   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 # )
+
+# create the appropriate files for tools
+file(GLOB SUBDIRS ${PROJECT_SOURCE_DIR}/3Dwarehouse/tools/*)
+foreach(SUBDIR ${SUBDIRS})
+    get_filename_component(MODEL_NAME ${SUBDIR} NAME)
+    set(MODEL_DIR ${CATKIN_PACKAGE_SHARE_DESTINATION}/models/${MODEL_NAME})
+
+    # create the description.sdf for the model
+    configure_file(
+        ${PROJECT_SOURCE_DIR}/description.sdf.template
+        ${MODEL_DIR}/sdf/description.sdf
+    )
+
+    # move the mesh files
+    file(GLOB MESH ${SUBDIR}/*.dae)
+    file(COPY ${MESH} DESTINATION ${MODEL_DIR}/mesh)
+
+    # move the color files
+
+endforeach()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,13 +4,6 @@ project(warehouse)
 find_package(catkin REQUIRED)
 catkin_package()
 
-## Mark other files for installation (e.g. launch and bag files, etc.)
-# install(FILES
-#   # myfile1
-#   # myfile2
-#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-# )
-
 # create the appropriate files for tools
 file(GLOB SUBDIRS ${PROJECT_SOURCE_DIR}/3Dwarehouse/tools/*)
 foreach(SUBDIR ${SUBDIRS})
@@ -23,10 +16,15 @@ foreach(SUBDIR ${SUBDIRS})
         ${MODEL_DIR}/sdf/description.sdf
     )
 
-    # move the mesh files
-    file(GLOB MESH ${SUBDIR}/*.dae)
-    file(COPY ${MESH} DESTINATION ${MODEL_DIR}/mesh)
+    # move mesh files
+    file(GLOB MESHES ${SUBDIR}/*.dae)
+    file(COPY ${MESHES} DESTINATION ${MODEL_DIR}/mesh)
 
-    # move the color files
-
+    # move texture folders into the mesh directory
+    file(GLOB TEXTURES ${SUBDIR}/*)
+    foreach(TEXTURE ${TEXTURES})
+        if(IS_DIRECTORY ${TEXTURE})
+            file(COPY ${TEXTURE} DESTINATION ${MODEL_DIR}/mesh)
+        endif()
+    endforeach()
 endforeach()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,10 +5,12 @@ find_package(catkin REQUIRED)
 catkin_package()
 
 # create the appropriate files for tools
+set(BUILD_MODEL_DIR ${PROJECT_SOURCE_DIR}/warehouse)
+
 file(GLOB SUBDIRS ${PROJECT_SOURCE_DIR}/3Dwarehouse/tools/*)
 foreach(SUBDIR ${SUBDIRS})
     get_filename_component(MODEL_NAME ${SUBDIR} NAME)
-    set(MODEL_DIR ${CATKIN_PACKAGE_SHARE_DESTINATION}/models/${MODEL_NAME})
+    set(MODEL_DIR ${BUILD_MODEL_DIR}/models/${MODEL_NAME})
 
     # create the description.sdf for the model
     configure_file(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.0.2)
+project(warehouse)
+
+find_package(catkin REQUIRED)
+
+## Mark other files for installation (e.g. launch and bag files, etc.)
+# install(FILES
+#   # myfile1
+#   # myfile2
+#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+# )

--- a/description.sdf.template
+++ b/description.sdf.template
@@ -18,7 +18,7 @@
             <visual name="visual">
                 <geometry>
                     <mesh>
-                        <uri>model://@PROJECT_NAME@/models/@MODEL_NAME@/mesh/@MODEL_NAME@_origin.dae</uri>
+                        <uri>file://@BUILD_MODEL_DIR@/models/@MODEL_NAME@/mesh/@MODEL_NAME@_origin.dae</uri>
                         <scale>1 1 1</scale>
                     </mesh>
                 </geometry>

--- a/description.sdf.template
+++ b/description.sdf.template
@@ -1,0 +1,28 @@
+<?xml version='1.0'?>
+<sdf version="1.4">
+    <model name="@MODEL_NAME@_origin">
+        <static>true</static>
+        <link name="link">
+            <collision name="collision">
+                <surface>
+                    <contact>
+                        <collide_without_contact>true</collide_without_contact>
+                    </contact>
+                </surface>
+                <geometry>
+                    <box>
+                        <size>0.1 0.1 0.1</size>
+                    </box>
+                </geometry>
+            </collision>
+            <visual name="visual">
+                <geometry>
+                    <mesh>
+                        <uri>model://@PROJECT_NAME@/models/@MODEL_NAME@/mesh/@MODEL_NAME@_origin.dae</uri>
+                        <scale>1 1 1</scale>
+                    </mesh>
+                </geometry>
+            </visual>
+        </link>
+    </model>
+</sdf>

--- a/description.sdf.template
+++ b/description.sdf.template
@@ -18,7 +18,7 @@
             <visual name="visual">
                 <geometry>
                     <mesh>
-                        <uri>file://@BUILD_MODEL_DIR@/models/@MODEL_NAME@/mesh/@MODEL_NAME@_origin.dae</uri>
+                        <uri>model://@MODEL_NAME@/mesh/@MODEL_NAME@_origin.dae</uri>
                         <scale>1 1 1</scale>
                     </mesh>
                 </geometry>

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>simData</name>
+  <version>0.0.0</version>
+  <description>The simData package</description>
+
+  <!-- One maintainer tag required, multiple allowed, one person per tag -->
+  <!-- Example:  -->
+  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
+  <maintainer email="anthony@todo.todo">anthony</maintainer>
+
+
+  <!-- One license tag required, multiple allowed, one license per tag -->
+  <!-- Commonly used license strings: -->
+  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
+  <license>TODO</license>
+
+
+  <!-- Url tags are optional, but multiple are allowed, one per tag -->
+  <!-- Optional attribute type can be: website, bugtracker, or repository -->
+  <!-- Example: -->
+  <!-- <url type="website">http://wiki.ros.org/simData</url> -->
+
+
+  <!-- Author tags are optional, multiple are allowed, one per tag -->
+  <!-- Authors do not have to be maintainers, but could be -->
+  <!-- Example: -->
+  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
+
+
+  <!-- The *depend tags are used to specify dependencies -->
+  <!-- Dependencies can be catkin packages or system dependencies -->
+  <!-- Examples: -->
+  <!-- Use depend as a shortcut for packages that are both build and exec dependencies -->
+  <!--   <depend>roscpp</depend> -->
+  <!--   Note that this is equivalent to the following: -->
+  <!--   <build_depend>roscpp</build_depend> -->
+  <!--   <exec_depend>roscpp</exec_depend> -->
+  <!-- Use build_depend for packages you need at compile time: -->
+  <!--   <build_depend>message_generation</build_depend> -->
+  <!-- Use build_export_depend for packages you need in order to build against this package: -->
+  <!--   <build_export_depend>message_generation</build_export_depend> -->
+  <!-- Use buildtool_depend for build tool packages: -->
+  <!--   <buildtool_depend>catkin</buildtool_depend> -->
+  <!-- Use exec_depend for packages you need at runtime: -->
+  <!--   <exec_depend>message_runtime</exec_depend> -->
+  <!-- Use test_depend for packages you need only for testing: -->
+  <!--   <test_depend>gtest</test_depend> -->
+  <!-- Use doc_depend for packages you need only for building documentation: -->
+  <!--   <doc_depend>doxygen</doc_depend> -->
+  <buildtool_depend>catkin</buildtool_depend>
+
+
+  <!-- The export tag contains other, unspecified, tags -->
+  <export>
+    <!-- Other tools can request additional information be placed here -->
+
+  </export>
+</package>

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>warehouse</name>
-  <version>0.0.0</version>
+  <version>0.1.0</version>
   <description>The simData package with warehouse models</description>
 
   <maintainer email="acmiyaguchi@gatech.edu" />
@@ -13,6 +13,6 @@
     <!-- gazebo_ros_paths_plugin automatically adds these to
         GAZEBO_PLUGIN_PATH and GAZEBO_MODEL_PATH when you do this export inside
         the package.xml file. You can than use URIs of type model://my_package/stuff. -->
-    <gazebo_ros gazebo_plugin_path="${prefix}/lib" gazebo_model_path="${prefix}/.." />
+    <!-- <gazebo_ros gazebo_plugin_path="${prefix}/lib" gazebo_model_path="${prefix}/.." /> -->
   </export>
 </package>

--- a/package.xml
+++ b/package.xml
@@ -7,12 +7,14 @@
   <maintainer email="acmiyaguchi@gatech.edu" />
   <license>BSD</license>
   <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>gazebo_ros</build_depend>
+  <exec_depend>gazebo_ros</exec_depend>
 
   <export>
     <!-- https://answers.gazebosim.org/question/6568/uri-paths-to-packages-in-the-sdf-model-file/?answer=7664#post-id-7664 -->
     <!-- gazebo_ros_paths_plugin automatically adds these to
         GAZEBO_PLUGIN_PATH and GAZEBO_MODEL_PATH when you do this export inside
         the package.xml file. You can than use URIs of type model://my_package/stuff. -->
-    <!-- <gazebo_ros gazebo_plugin_path="${prefix}/lib" gazebo_model_path="${prefix}/.." /> -->
+    <gazebo_ros gazebo_plugin_path="${prefix}/lib" gazebo_model_path="${prefix}/models" />
   </export>
 </package>

--- a/package.xml
+++ b/package.xml
@@ -1,59 +1,18 @@
 <?xml version="1.0"?>
 <package format="2">
-  <name>simData</name>
+  <name>warehouse</name>
   <version>0.0.0</version>
-  <description>The simData package</description>
+  <description>The simData package with warehouse models</description>
 
-  <!-- One maintainer tag required, multiple allowed, one person per tag -->
-  <!-- Example:  -->
-  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
-  <maintainer email="anthony@todo.todo">anthony</maintainer>
-
-
-  <!-- One license tag required, multiple allowed, one license per tag -->
-  <!-- Commonly used license strings: -->
-  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
-  <license>TODO</license>
-
-
-  <!-- Url tags are optional, but multiple are allowed, one per tag -->
-  <!-- Optional attribute type can be: website, bugtracker, or repository -->
-  <!-- Example: -->
-  <!-- <url type="website">http://wiki.ros.org/simData</url> -->
-
-
-  <!-- Author tags are optional, multiple are allowed, one per tag -->
-  <!-- Authors do not have to be maintainers, but could be -->
-  <!-- Example: -->
-  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
-
-
-  <!-- The *depend tags are used to specify dependencies -->
-  <!-- Dependencies can be catkin packages or system dependencies -->
-  <!-- Examples: -->
-  <!-- Use depend as a shortcut for packages that are both build and exec dependencies -->
-  <!--   <depend>roscpp</depend> -->
-  <!--   Note that this is equivalent to the following: -->
-  <!--   <build_depend>roscpp</build_depend> -->
-  <!--   <exec_depend>roscpp</exec_depend> -->
-  <!-- Use build_depend for packages you need at compile time: -->
-  <!--   <build_depend>message_generation</build_depend> -->
-  <!-- Use build_export_depend for packages you need in order to build against this package: -->
-  <!--   <build_export_depend>message_generation</build_export_depend> -->
-  <!-- Use buildtool_depend for build tool packages: -->
-  <!--   <buildtool_depend>catkin</buildtool_depend> -->
-  <!-- Use exec_depend for packages you need at runtime: -->
-  <!--   <exec_depend>message_runtime</exec_depend> -->
-  <!-- Use test_depend for packages you need only for testing: -->
-  <!--   <test_depend>gtest</test_depend> -->
-  <!-- Use doc_depend for packages you need only for building documentation: -->
-  <!--   <doc_depend>doxygen</doc_depend> -->
+  <maintainer email="acmiyaguchi@gatech.edu" />
+  <license>BSD</license>
   <buildtool_depend>catkin</buildtool_depend>
 
-
-  <!-- The export tag contains other, unspecified, tags -->
   <export>
-    <!-- Other tools can request additional information be placed here -->
-
+    <!-- https://answers.gazebosim.org/question/6568/uri-paths-to-packages-in-the-sdf-model-file/?answer=7664#post-id-7664 -->
+    <!-- gazebo_ros_paths_plugin automatically adds these to
+        GAZEBO_PLUGIN_PATH and GAZEBO_MODEL_PATH when you do this export inside
+        the package.xml file. You can than use URIs of type model://my_package/stuff. -->
+    <gazebo_ros gazebo_plugin_path="${prefix}/lib" gazebo_model_path="${prefix}/.." />
   </export>
 </package>


### PR DESCRIPTION
This follows the general instructions in https://github.com/ivalab/simData_imgSaver for preprocessing images. This should replace some of the matlab scripts with CMake instead. 

https://github.com/ivalab/simData_imgSaver/blob/master/utils/move_model_files.m

This approach has the benefit of being integrated into the catkin workflow, and also does not rely on hardcoding values or changing the repository after checkout. I tried to set this up so that the files could be found in the installation directory, and added to the gazebo path directly. However, I had issues with the `$(find warehouse)` action in the `roslaunch` file, so we have to deal with absolute paths in the generated files.
